### PR TITLE
Fix Z80 source code configuration

### DIFF
--- a/pasopiaemulator/CMakeLists.txt
+++ b/pasopiaemulator/CMakeLists.txt
@@ -15,10 +15,6 @@ target_sources(pasopiaemulator PRIVATE pasopiaemulator.c Z80.c hid_app.c joystic
 pico_enable_stdio_usb(pasopiaemulator 0)
 pico_enable_stdio_uart(pasopiaemulator 1)
 
-set(Z80_SHARED_LIBS                 NO  CACHE BOOL "")
-set(Z80_WITH_Q                      YES CACHE BOOL "")
-set(Z80_WITH_ZILOG_NMOS_LD_A_IR_BUG YES CACHE BOOL "")
-set(Z80_USE_LOCAL_HEADER            YES CACHE BOOL "")
-
+target_compile_definitions(pasopiaemulator PRIVATE Z80_STATIC Z80_WITH_LOCAL_HEADER Z80_WITH_Q Z80_WITH_ZILOG_NMOS_LD_A_IR_BUG)
 target_link_libraries(pasopiaemulator PRIVATE pico_stdlib hardware_pio hardware_timer hardware_dma hardware_uart hardware_flash pico_multicore hardware_pwm tinyusb_host tinyusb_board)
 pico_add_extra_outputs(pasopiaemulator)


### PR DESCRIPTION
このプルリクエストはZ80ソースコードを正しく設定します。Z80ソースコードをプロジェクトにコピーしているので、CMakeオプションを使用する必要はありません。代わりに、対応する設定マクロを事前に定義しておく必要があります。